### PR TITLE
Add editor registration for Xhtmlstring on the HtmlEditorDescription.

### DIFF
--- a/src/AceEditor/Editors/HtmlEditorDescriptor.cs
+++ b/src/AceEditor/Editors/HtmlEditorDescriptor.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Web;
+using EPiServer.Core;
 using EPiServer.Shell.ObjectEditing;
 using EPiServer.Shell.ObjectEditing.EditorDescriptors;
 
@@ -9,6 +10,10 @@ namespace AceEditor.Editors
 {
     [EditorDescriptorRegistration(
         TargetType = typeof(string),
+        UIHint = UIHints.Html,
+        EditorDescriptorBehavior = EditorDescriptorBehavior.PlaceLast)]
+    [EditorDescriptorRegistration(
+        TargetType = typeof(XhtmlString),
         UIHint = UIHints.Html,
         EditorDescriptorBehavior = EditorDescriptorBehavior.PlaceLast)]
     public class HtmlEditorDescriptor : AceEditorDescriptor


### PR DESCRIPTION
This allows embedded blocks (copy/paste from regular xhtmlstring editor) and @Html.ProperyFor to work in views for html content.
