### PR TITLE
Fix on-page edit mode and clean up targets usage

### DIFF
--- a/pack.v12.ps1
+++ b/pack.v12.ps1
@@ -1,5 +1,5 @@
 $outputDir = "..\..\package\"
 $build = "Release"
-$version = "12.1.1"
+$version = "12.1.2"
 
 msbuild -t:pack ".\src\AceEditor\AceEditor.v12.csproj" -p:Configuration=$build -p:PackageVersion=$version -p:PackageOutputPath=$outputDir

--- a/src/AceEditor/AceEditor.targets
+++ b/src/AceEditor/AceEditor.targets
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Target Name="AceEditorCopyContentFiles" BeforeTargets="Build">
-        <Message Text="Copy content files to project" />
-        <ItemGroup>
-            <SourceScripts Include="$(MSBuildThisFileDirectory)..\..\contentFiles\any\any\modules\_protected\**\*.*"/>
-        </ItemGroup>
-        <Copy SourceFiles="@(SourceScripts)" DestinationFolder="$(MSBuildProjectDirectory)\modules\_protected\%(RecursiveDir)" />
+    <ItemGroup>
+        <SourceScripts Include="$(MSBuildThisFileDirectory)..\..\contentFiles\any\any\modules\_protected\**\*.zip"/>
+    </ItemGroup>
+
+    <Target Name="CopyZipFiles" BeforeTargets="Build">
+        <Copy SkipUnchangedFiles="true" SourceFiles="@(SourceScripts)" DestinationFolder="$(MSBuildProjectDirectory)\modules\_protected\%(RecursiveDir)" />
     </Target>
 </Project>

--- a/src/AceEditor/AceEditor.targets
+++ b/src/AceEditor/AceEditor.targets
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Target Name="CopyContentFiles" BeforeTargets="Build">
+    <Target Name="AceEditorCopyContentFiles" BeforeTargets="Build">
         <Message Text="Copy content files to project" />
         <ItemGroup>
             <SourceScripts Include="$(MSBuildThisFileDirectory)..\..\contentFiles\any\any\modules\_protected\**\*.*"/>

--- a/src/AceEditor/AceEditor.v12.csproj
+++ b/src/AceEditor/AceEditor.v12.csproj
@@ -9,7 +9,7 @@
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Authors>Hieu Nguyen Trung, David Knipe</Authors>
-    <Version>12.1.1</Version>
+    <Version>12.1.2</Version>
     <Company>Hieu Nguyen Trung</Company>
     <Description>Integrate AceEditor into EPiServer</Description>
     <Copyright>Copyright © 2017</Copyright>
@@ -523,7 +523,7 @@
       <Pack>true</Pack>
       <PackagePath>contentFiles\any\any\modules\_protected\AceEditor</PackagePath>
     </Content>
-    <Content Include="$(SolutionDir)\AceEditor.targets" >
+    <Content Include="AceEditor.targets">
       <Pack>true</Pack>
       <PackagePath>build\net5.0\AceEditor.targets</PackagePath>
     </Content>

--- a/src/AceEditor/ClientResources/Scripts/AceEditor/aceEditor.js
+++ b/src/AceEditor/ClientResources/Scripts/AceEditor/aceEditor.js
@@ -199,14 +199,14 @@
                     var ed = this.getEditor(),
                         editableValue = newValue || "";
 
-                    this._set("value", newValue);
+                    this._set("value", editableValue);
 
                     // If the editor has started, set the content to it
                     // otherwise it will be set from the textarea when tiny inits
                     if (ed) {
                         this.editorSession.setValue(editableValue);
                     } else {
-                        $(this.editorFrame).text(editableValue);
+                        this.editorFrame.textContent = editableValue;
                     }
 
                     this.inherited(arguments);


### PR DESCRIPTION
Fix for issue #12 - jquery is not available at this call in CMS 12 and fails silently.

Additional adjustments may also be a fix for #13 as .NET5+ packages must be copied via targets and the target name can easily conflict with other packages